### PR TITLE
Tweak conversion mechanics to be more explicit and safe.

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -4,9 +4,8 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
-        <option name="testRunner" value="GRADLE" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="corretto-17" />
+        <option name="gradleJvm" value="#GRADLE_LOCAL_JAVA_HOME" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />
@@ -14,6 +13,7 @@
             <option value="$PROJECT_DIR$/uma-sdk" />
           </set>
         </option>
+        <option name="resolveExternalAnnotations" value="false" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/.idea/migrations.xml
+++ b/.idea/migrations.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectMigrations">
+    <option name="MigrateToGradleLocalJavaHome">
+      <set>
+        <option value="$PROJECT_DIR$" />
+      </set>
+    </option>
+  </component>
+</project>

--- a/uma-sdk/src/commonMain/kotlin/me/uma/Version.kt
+++ b/uma-sdk/src/commonMain/kotlin/me/uma/Version.kt
@@ -6,7 +6,7 @@ import kotlinx.serialization.json.encodeToJsonElement
 import kotlinx.serialization.json.put
 
 const val MAJOR_VERSION = 0
-const val MINOR_VERSION = 1
+const val MINOR_VERSION = 2
 const val UMA_VERSION_STRING = "$MAJOR_VERSION.$MINOR_VERSION"
 
 /**

--- a/uma-sdk/src/commonMain/kotlin/me/uma/protocol/Currency.kt
+++ b/uma-sdk/src/commonMain/kotlin/me/uma/protocol/Currency.kt
@@ -26,7 +26,7 @@ data class Currency @JvmOverloads constructor(
      * Estimated millisats per smallest "unit" of this currency (eg. 1 cent in USD).
      */
     @SerialName("multiplier")
-    val millisatoshiPerUnit: Long,
+    val millisatoshiPerUnit: Double,
 
     /**
      * Minimum amount that can be sent in this currency. This is in the smallest unit of the currency
@@ -41,13 +41,16 @@ data class Currency @JvmOverloads constructor(
     val maxSendable: Long,
 
     /**
-     * Number of digits after the decimal point for display on the sender side. For example,
-     * in USD, by convention, there are 2 digits for cents - $5.95. in this case, `decimals`
-     * would be 2. Note that the multiplier is still always in the smallest unit (cents). This field
-     * is only for display purposes. The sender should assume zero if this field is omitted, unless
-     * they know the proper display format of the target currency.
+     * The number of digits after the decimal point for display on the sender side, and to add clarity
+     * around what the "smallest unit" of the currency is. For example, in USD, by convention, there are 2 digits for
+     * cents - $5.95. In this case, `decimals` would be 2. Note that the multiplier is still always in the smallest
+     * unit (cents). In addition to display purposes, this field can be used to resolve ambiguity in what the multiplier
+     * means. For example, if the currency is "BTC" and the multiplier is 1000, really we're exchanging in SATs, so
+     * `decimals` would be 8.
+     *
+     * For details on edge cases and examples, see https://github.com/uma-universal-money-address/protocol/blob/main/umad-04-lnurlp-response.md.
      */
-    val decimals: Int? = null,
+    val decimals: Int,
 ) {
     fun toJson() = Json.encodeToString(this)
 }


### PR DESCRIPTION
- Make the decimals field on `Currency` required and change its description to include more details about its use.
- Change the multiplier field from long to double to allow for very small unit currencies. See https://github.com/uma-universal-money-address/protocol/blob/main/umad-04-lnurlp-response.md for details on why this is needed.

NOTE: This is technically a breaking change. Given that we're not yet at UMA 1.0, I'm bumping the protocol version here to 0.2 to indicate the bump and to be able to tell what version the counterparty is using for debugging.