### PR TITLE
Fix the lnurlp signature verification. No hash needed.

### DIFF
--- a/.idea/artifacts/uma_sdk_jvm.xml
+++ b/.idea/artifacts/uma_sdk_jvm.xml
@@ -1,6 +1,8 @@
 <component name="ArtifactManager">
   <artifact type="jar" name="uma-sdk-jvm">
     <output-path>$PROJECT_DIR$/uma-sdk/build/libs</output-path>
-    <root id="archive" name="uma-sdk-jvm.jar" />
+    <root id="archive" name="uma-sdk-jvm.jar">
+      <element id="module-output" name="uma-kotlin-sdk.uma-sdk.jvmMain" />
+    </root>
   </artifact>
 </component>

--- a/javatest/src/test/java/me/uma/javatest/UmaTest.java
+++ b/javatest/src/test/java/me/uma/javatest/UmaTest.java
@@ -101,6 +101,8 @@ public class UmaTest {
         LnurlpResponse parsedResponse = umaProtocolHelper.parseAsLnurlpResponse(responseJson);
         assertNotNull(parsedResponse);
         assertEquals(lnurlpResponse, parsedResponse);
+        assertTrue(umaProtocolHelper.verifyLnurlpResponseSignature(
+                parsedResponse, new PubKeyResponse(publicKeyBytes(), publicKeyBytes())));
     }
 
     @Test

--- a/uma-sdk/src/commonMain/kotlin/me/uma/UmaProtocolHelper.kt
+++ b/uma-sdk/src/commonMain/kotlin/me/uma/UmaProtocolHelper.kt
@@ -2,7 +2,6 @@
 
 package me.uma
 
-import java.security.MessageDigest
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Future
 import kotlin.math.roundToLong
@@ -221,9 +220,11 @@ class UmaProtocolHelper @JvmOverloads constructor(
      * @param pubKeyResponse The [PubKeyResponse] that contains the public key of the receiver.
      */
     fun verifyLnurlpResponseSignature(response: LnurlpResponse, pubKeyResponse: PubKeyResponse): Boolean {
-        val signablePayload = response.compliance.signablePayload()
-        val hashedPayload = MessageDigest.getInstance("SHA-256").digest(signablePayload)
-        return verifySignature(hashedPayload, response.compliance.signature, pubKeyResponse.signingPubKey)
+        return verifySignature(
+            response.compliance.signablePayload(),
+            response.compliance.signature,
+            pubKeyResponse.signingPubKey,
+        )
     }
 
     /**


### PR DESCRIPTION
The hashing of the message is already done in the crypto module.