### PR TITLE
Fix the logic around when the port is included in the receiver signature

### DIFF
--- a/uma-sdk/src/commonMain/kotlin/me/uma/protocol/LnurlpRequest.kt
+++ b/uma-sdk/src/commonMain/kotlin/me/uma/protocol/LnurlpRequest.kt
@@ -70,8 +70,11 @@ data class LnurlpRequest(
             ) {
                 throw IllegalArgumentException("Invalid uma request path: $url")
             }
-            val port =
-                if (urlBuilder.port != 443 && urlBuilder.port != 80 && urlBuilder.port != 0) ":${urlBuilder.port}" else ""
+            val port = if (urlBuilder.port != 443 && urlBuilder.port != 80 && urlBuilder.port != 0) {
+                ":${urlBuilder.port}"
+            } else {
+                ""
+            }
             val receiverAddress = "${urlBuilder.pathSegments[3]}@${urlBuilder.host}$port"
             val vaspDomain = urlBuilder.parameters["vaspDomain"]
             val nonce = urlBuilder.parameters["nonce"]

--- a/uma-sdk/src/commonMain/kotlin/me/uma/protocol/LnurlpRequest.kt
+++ b/uma-sdk/src/commonMain/kotlin/me/uma/protocol/LnurlpRequest.kt
@@ -70,7 +70,7 @@ data class LnurlpRequest(
             ) {
                 throw IllegalArgumentException("Invalid uma request path: $url")
             }
-            val port = if (isDomainLocalhost(urlBuilder.host)) ":${urlBuilder.port}" else ""
+            val port = if (urlBuilder.port != 443 && urlBuilder.port != 80) ":${urlBuilder.port}" else ""
             val receiverAddress = "${urlBuilder.pathSegments[3]}@${urlBuilder.host}$port"
             val vaspDomain = urlBuilder.parameters["vaspDomain"]
             val nonce = urlBuilder.parameters["nonce"]

--- a/uma-sdk/src/commonMain/kotlin/me/uma/protocol/LnurlpRequest.kt
+++ b/uma-sdk/src/commonMain/kotlin/me/uma/protocol/LnurlpRequest.kt
@@ -70,7 +70,8 @@ data class LnurlpRequest(
             ) {
                 throw IllegalArgumentException("Invalid uma request path: $url")
             }
-            val port = if (urlBuilder.port != 443 && urlBuilder.port != 80) ":${urlBuilder.port}" else ""
+            val port =
+                if (urlBuilder.port != 443 && urlBuilder.port != 80 && urlBuilder.port != 0) ":${urlBuilder.port}" else ""
             val receiverAddress = "${urlBuilder.pathSegments[3]}@${urlBuilder.host}$port"
             val vaspDomain = urlBuilder.parameters["vaspDomain"]
             val nonce = urlBuilder.parameters["nonce"]


### PR DESCRIPTION
This is only needed if the port is explicitly specified in the receiver address, which usually means the port isn't 80 or 443. This fixes some weirdness when testing with local vasps on port 80.