### PR TITLE
Encode default values for tag and routes

### DIFF
--- a/javatest/src/test/java/me/uma/javatest/UmaTest.java
+++ b/javatest/src/test/java/me/uma/javatest/UmaTest.java
@@ -29,8 +29,8 @@ import me.uma.protocol.PubKeyResponse;
 
 public class UmaTest {
     UmaProtocolHelper umaProtocolHelper = new UmaProtocolHelper(new InMemoryPublicKeyCache(), new TestUmaRequester());
-    private static String PUBKEY_HEX = "04f2998ab056897ddb91b5e6fad1e4bb6c4b7dda427409f667d0f4694b553e4feeeb08936c2993f7b931f6a3fa7e846f11165fae222de5e4a55c12def21a7c9fcf";
-    private static String PRIVKEY_HEX = "10fbbee8f689b207bb22df2dfa27827ae9ae02e265980ea09ef5101ed5fb508f";
+    private static final String PUBKEY_HEX = "04f2998ab056897ddb91b5e6fad1e4bb6c4b7dda427409f667d0f4694b553e4feeeb08936c2993f7b931f6a3fa7e846f11165fae222de5e4a55c12def21a7c9fcf";
+    private static final String PRIVKEY_HEX = "10fbbee8f689b207bb22df2dfa27827ae9ae02e265980ea09ef5101ed5fb508f";
 
 
     @Test

--- a/uma-sdk/src/commonMain/kotlin/me/uma/protocol/LnurlpResponse.kt
+++ b/uma-sdk/src/commonMain/kotlin/me/uma/protocol/LnurlpResponse.kt
@@ -1,12 +1,9 @@
 package me.uma.protocol
 
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.descriptors.buildClassSerialDescriptor
 import kotlinx.serialization.descriptors.element
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.encoding.CompositeDecoder
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
@@ -29,6 +26,7 @@ import kotlinx.serialization.json.Json
  *     support and VASP1's specified preference in the LnurlpRequest. For the version negotiation flow, see
  * 	   https://static.swimlanes.io/87f5d188e080cb8e0494e46f80f2ae74.png
  */
+@OptIn(ExperimentalSerializationApi::class)
 @Serializable
 data class LnurlpResponse(
     val callback: String,
@@ -40,6 +38,7 @@ data class LnurlpResponse(
     val requiredPayerData: PayerDataOptions,
     val compliance: LnurlComplianceResponse,
     val umaVersion: String,
+    @EncodeDefault
     val tag: String = "payRequest",
 ) {
     fun toJson() = Json.encodeToString(this)

--- a/uma-sdk/src/commonMain/kotlin/me/uma/protocol/PayReqResponse.kt
+++ b/uma-sdk/src/commonMain/kotlin/me/uma/protocol/PayReqResponse.kt
@@ -1,8 +1,6 @@
 package me.uma.protocol
 
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.*
 import kotlinx.serialization.json.Json
 
 /**
@@ -14,12 +12,14 @@ import kotlinx.serialization.json.Json
  * @property compliance The compliance data from the receiver, including utxo info.
  * @property paymentInfo The payment info from the receiver, including currency and an updated conversion rate.
  */
+@OptIn(ExperimentalSerializationApi::class)
 @Serializable
 data class PayReqResponse(
     @SerialName("pr")
     val encodedInvoice: String,
     val compliance: PayReqResponseCompliance,
     val paymentInfo: PayReqResponsePaymentInfo,
+    @EncodeDefault
     val routes: List<Route> = emptyList(),
 ) {
     fun toJson() = Json.encodeToString(this)


### PR DESCRIPTION
This ensures that these keys will exist on the resulting json responses.