### PR TITLE
Fix version future-proofing with isUmaLnurlpQuery.

### DIFF
--- a/uma-sdk/src/commonMain/kotlin/me/uma/protocol/LnurlpRequest.kt
+++ b/uma-sdk/src/commonMain/kotlin/me/uma/protocol/LnurlpRequest.kt
@@ -83,6 +83,10 @@ data class LnurlpRequest(
             val timestamp = urlBuilder.parameters["timestamp"]?.toLong()
             val umaVersion = urlBuilder.parameters["umaVersion"]
 
+            if (umaVersion != null && !isVersionSupported(umaVersion)) {
+                throw UnsupportedVersionException(umaVersion)
+            }
+
             if (vaspDomain == null ||
                 nonce == null ||
                 signature == null ||
@@ -91,10 +95,6 @@ data class LnurlpRequest(
                 umaVersion == null
             ) {
                 throw IllegalArgumentException("Invalid URL. Missing param: $url")
-            }
-
-            if (!isVersionSupported(umaVersion)) {
-                throw UnsupportedVersionException(umaVersion)
             }
 
             return LnurlpRequest(

--- a/uma-sdk/src/commonTest/kotlin/me/uma/UmaTests.kt
+++ b/uma-sdk/src/commonTest/kotlin/me/uma/UmaTests.kt
@@ -55,4 +55,10 @@ class UmaTests {
             String(Secp256k1.decryptEcies(encryptedTravelRuleInfo.hexToByteArray(), keys.privateKey)),
         )
     }
+
+    @Test
+    fun `test isUmaLnurlpQuery future-proofing`() {
+        val umaLnurlpQuery = "https://example.com/.well-known/lnurlp/\$bob?vaspDomain=example.com&nonce=123&signature=123&isSubjectToTravelRule=true&timestamp=123&umaVersion=100.0"
+        assertEquals(true, UmaProtocolHelper().isUmaLnurlpQuery(umaLnurlpQuery))
+    }
 }

--- a/uma-sdk/src/commonTest/kotlin/me/uma/UmaTests.kt
+++ b/uma-sdk/src/commonTest/kotlin/me/uma/UmaTests.kt
@@ -58,7 +58,9 @@ class UmaTests {
 
     @Test
     fun `test isUmaLnurlpQuery future-proofing`() {
-        val umaLnurlpQuery = "https://example.com/.well-known/lnurlp/\$bob?vaspDomain=example.com&nonce=123&signature=123&isSubjectToTravelRule=true&timestamp=123&umaVersion=100.0"
+        val umaLnurlpQuery =
+            "https://example.com/.well-known/lnurlp/\$bob?vaspDomain=example.com&nonce=123&signature=123&" +
+                "isSubjectToTravelRule=true&timestamp=123&umaVersion=100.0"
         assertEquals(true, UmaProtocolHelper().isUmaLnurlpQuery(umaLnurlpQuery))
     }
 }


### PR DESCRIPTION
Future versions of UMA may change fields in this request, etc. so treating a parse failure as "non-uma" isn't the right behavior. We should throw the UnsupportedVersionException before trying to parse other fields.