### PR TITLE
Remove null-checks for non-uma lnurl request

### DIFF
--- a/uma-sdk/src/commonMain/kotlin/me/uma/protocol/LnurlpRequest.kt
+++ b/uma-sdk/src/commonMain/kotlin/me/uma/protocol/LnurlpRequest.kt
@@ -111,16 +111,6 @@ data class LnurlpRequest(
                 throw UnsupportedVersionException(umaVersion)
             }
 
-            if (vaspDomain == null ||
-                nonce == null ||
-                signature == null ||
-                isSubjectToTravelRule == null ||
-                timestamp == null ||
-                umaVersion == null
-            ) {
-                throw IllegalArgumentException("Invalid URL. Missing param: $url")
-            }
-
             return LnurlpRequest(
                 receiverAddress,
                 nonce,


### PR DESCRIPTION
these are enforced when converting to `UmaLnurlpRequest` [here](https://github.com/uma-universal-money-address/uma-kotlin-sdk/blob/0dbcfa78102ed264665974d509831a168fbafd38/uma-sdk/src/commonMain/kotlin/me/uma/protocol/LnurlpRequest.kt#L64) 