### PR TITLE
add signature verification for invoices

### DIFF
--- a/uma-sdk/src/commonMain/kotlin/me/uma/protocol/Invoice.kt
+++ b/uma-sdk/src/commonMain/kotlin/me/uma/protocol/Invoice.kt
@@ -22,8 +22,6 @@ data class InvoiceCurrency(
     val decimals: Int,
 ) : TLVCodeable {
     companion object {
-        val EMPTY = InvoiceCurrency("", "", "", 0)
-
         fun fromTLV(bytes: ByteArray): InvoiceCurrency {
             var code = ""
             var name = ""
@@ -70,7 +68,7 @@ class InvoiceCurrencyTLVSerializer : KSerializer<InvoiceCurrency> {
 }
 
 @Serializable(with = InvoiceTLVSerializer::class)
-class Invoice(
+data class Invoice(
     val receiverUma: String,
     /** Invoice UUID Served as both the identifier of the UMA invoice, and the validation of proof of payment.*/
     val invoiceUUID: String,
@@ -123,6 +121,15 @@ class Invoice(
             UMA_BECH32_PREFIX,
             this.toTLV(),
         )
+    }
+
+    /**
+     * return the Invoice serialized in TLV format, without signature
+     * this represents the payload that is then signed and then assigned to the signature
+     * property
+     */
+    fun toSignablePayload(): ByteArray {
+        return this.copy(signature = null).toTLV()
     }
 
     companion object {

--- a/uma-sdk/src/commonTest/kotlin/me/uma/UmaTests.kt
+++ b/uma-sdk/src/commonTest/kotlin/me/uma/UmaTests.kt
@@ -97,6 +97,31 @@ class UmaTests {
     }
 
     @Test
+    fun `test verify invoice signature`() {
+        val invoice = UmaProtocolHelper().getInvoice(
+            receiverUma = "\$foo@bar.com",
+            invoiceUUID = "c7c07fec-cf00-431c-916f-6c13fc4b69f9",
+            amount = 1000,
+            receivingCurrency = InvoiceCurrency(code = "USD", name = "US Dollar", symbol = "$", decimals = 2),
+            expiration = 1000000,
+            isSubjectToTravelRule = true,
+            requiredPayerData = mapOf(
+                "name" to CounterPartyDataOption(false),
+                "email" to CounterPartyDataOption(false),
+                "compliance" to CounterPartyDataOption(true),
+            ),
+            commentCharsAllowed = null,
+            senderUma = null,
+            invoiceLimit = null,
+            umaVersion = "0.3",
+            kycStatus = KycStatus.VERIFIED,
+            callback = "https://example.com/callback",
+            privateSigningKey = keys.privateKey
+        )
+        assertTrue(UmaProtocolHelper().verifyUmaInvoice(invoice, PubKeyResponse(keys.publicKey, keys.publicKey)))
+    }
+
+    @Test
     fun `test create and parse payreq in receiving amount`() = runTest {
         val travelRuleInfo = "travel rule info"
         val payreq =


### PR DESCRIPTION
# Overview
Add private signature generation when creating Invoice

add verification function for incoming Invoices

# Test Plan
unit test to verify generated signature can be decoded with matching public key