### PR TITLE
Bump publish runner to macos-14

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   publish-uma-sdk:
-    runs-on: macos-12
+    runs-on: macos-14
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
macos-12 is deprecated.
