### PR TITLE
Bump Gradle version and fix deprecated `build.gradle.kts` usages

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="FrameworkDetectionExcludesConfiguration">

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import com.vanniktech.maven.publish.MavenPublishBaseExtension
 import com.vanniktech.maven.publish.SonatypeHost
 import org.jetbrains.dokka.gradle.DokkaMultiModuleTask
 import org.jetbrains.dokka.gradle.DokkaTaskPartial
-import java.net.URL
+import java.net.URI
 
 buildscript {
     dependencies {
@@ -30,10 +30,9 @@ subprojects {
         outputToConsole.set(true)
         debug.set(true)
         verbose.set(true)
-        disabledRules.set(setOf("no-wildcard-imports"))
     }
 
-    tasks.create<Exec>("bumpAndTagVersion") {
+    tasks.register<Exec>("bumpAndTagVersion") {
         group = "release"
         description = "Tags the current version in git."
         val cmd = mutableListOf("../scripts/versions.main.kts", "-f", "-t")
@@ -43,7 +42,7 @@ subprojects {
         commandLine(*cmd.toTypedArray())
     }
 
-    tasks.create<Exec>("bumpVersion") {
+    tasks.register<Exec>("bumpVersion") {
         group = "release"
         description = "Tags the current version in git."
         val cmd = mutableListOf("../scripts/versions.main.kts", "-f")
@@ -66,8 +65,8 @@ subprojects {
             }
             externalDocumentationLink {
                 // TODO: Update this link when API Reference docs are hosted publicly.
-                url.set(URL("https://app.lightspark.com/docs/reference/kotlin"))
-                packageListUrl.set(URL("https://app.lightspark.com/docs/reference/kotlin/package-list"))
+                url.set(URI("https://app.lightspark.com/docs/reference/kotlin").toURL())
+                packageListUrl.set(URI("https://app.lightspark.com/docs/reference/kotlin/package-list").toURL())
             }
         }
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
The idea is to make it easier, in the next PR, to use a Gradle task to format our Java files.